### PR TITLE
Adds error handling on missing tiles and 2nd option to fetch tiles local file system

### DIFF
--- a/tiles_to_tiff.py
+++ b/tiles_to_tiff.py
@@ -8,8 +8,12 @@ from tile_convert import bbox_to_xyz, tile_edges
 from osgeo import gdal
 
 #---------- CONFIGURATION -----------#
-tile_server = "https://api.mapbox.com/v4/mapbox.satellite/{z}/{x}/{y}.png?access_token=" + os.environ.get(
-    'MAPBOX_ACCESS_TOKEN')
+# Option 1: Online source
+tile_source = "https://api.mapbox.com/v4/mapbox.satellite/{z}/{x}/{y}.png?access_token=" + os.environ.get('MAPBOX_ACCESS_TOKEN')
+
+# Option 2: Local file system source
+#tile_source = "file:///D:/path_to/local_tiles/{z}/{x}/{y}.png"
+
 temp_dir = os.path.join(os.path.dirname(__file__), 'temp')
 output_dir = os.path.join(os.path.dirname(__file__), 'output')
 zoom = 16
@@ -20,8 +24,8 @@ lat_max = 65.31688
 #-----------------------------------#
 
 
-def download_tile(x, y, z, tile_server):
-    url = tile_server.replace(
+def fetch_tile(x, y, z, tile_source):
+    url = tile_source.replace(
         "{x}", str(x)).replace(
         "{y}", str(y)).replace(
         "{z}", str(z))
@@ -51,19 +55,19 @@ def georeference_raster_tile(x, y, z, path):
 x_min, x_max, y_min, y_max = bbox_to_xyz(
     lon_min, lon_max, lat_min, lat_max, zoom)
 
-print(f"Downloading {(x_max - x_min + 1) * (y_max - y_min + 1)} tiles")
+print(f"Fetching {(x_max - x_min + 1) * (y_max - y_min + 1)} tiles")
 
 for x in range(x_min, x_max + 1):
     for y in range(y_min, y_max + 1):
         try:
-            png_path = download_tile(x, y, zoom, tile_server)
+            png_path = fetch_tile(x, y, zoom, tile_source)
             print(f"{x},{y} fetched")
             georeference_raster_tile(x, y, zoom, png_path)
         except OSError:
             print(f"{x},{y} missing")
             pass
 
-print("Download complete")
+print("Fetching of tiles complete")
 
 print("Merging tiles")
 merge_tiles(temp_dir + '/*.tif', output_dir + '/merged.tif')

--- a/tiles_to_tiff.py
+++ b/tiles_to_tiff.py
@@ -45,7 +45,7 @@ def merge_tiles(input_pattern, output_path):
 
 def georeference_raster_tile(x, y, z, path):
     bounds = tile_edges(x, y, z)
-    filename = os.path.splitext(path)
+    filename, extension = os.path.splitext(path)
     gdal.Translate(filename + '.tif',
                    path,
                    outputSRS='EPSG:4326',

--- a/tiles_to_tiff.py
+++ b/tiles_to_tiff.py
@@ -41,7 +41,7 @@ def merge_tiles(input_pattern, output_path):
 
 def georeference_raster_tile(x, y, z, path):
     bounds = tile_edges(x, y, z)
-    filename, extension = os.path.splitext(path)
+    filename = os.path.splitext(path)
     gdal.Translate(filename + '.tif',
                    path,
                    outputSRS='EPSG:4326',
@@ -55,9 +55,13 @@ print(f"Downloading {(x_max - x_min + 1) * (y_max - y_min + 1)} tiles")
 
 for x in range(x_min, x_max + 1):
     for y in range(y_min, y_max + 1):
-        print(f"{x},{y}")
-        png_path = download_tile(x, y, zoom, tile_server)
-        georeference_raster_tile(x, y, zoom, png_path)
+        try:
+            png_path = download_tile(x, y, zoom, tile_server)
+            print(f"{x},{y} fetched")
+            georeference_raster_tile(x, y, zoom, png_path)
+        except OSError:
+            print(f"{x},{y} missing")
+            pass
 
 print("Download complete")
 


### PR DESCRIPTION
I had the use case to process some tiles on a local file system which were not evenly distributed but contained many gaps. My rudimentary error handling skips missing tiles which killed the process previously. Additionally, I included this local file system option and renamed some symbols to more general names in order to better fit both tile source options.